### PR TITLE
Made all the options configurable for added flexibility

### DIFF
--- a/supervisor/conf.sls
+++ b/supervisor/conf.sls
@@ -11,6 +11,16 @@ supervisor_job_{{ id }}:
     - template: jinja
     - id: {{ id }}
     - context: {{ process_data }}
+    - defaults:
+        autostart: "true"
+        autorestart: "unexpected"
+        startsecs: 1
+        startretries: 3
+        exitcodes: "0,2"
+        stopsignal: "TERM"
+        stopwaitsecs: 10
+        redirect_stderr: "false"
+        numprocs: 1
     - watch_in:
       - service: supervisor
     - require:

--- a/supervisor/templates/process.conf.jinja
+++ b/supervisor/templates/process.conf.jinja
@@ -2,12 +2,13 @@
 ; Source: {{ source }}
 [program:{{ id }}]
 command={{ command }}
-autostart=true
-autorestart=unexpected
-startsecs=1
-startretries=3
-exitcodes=0,2
-stopsignal=TERM
-stopwaitsecs=10
 user={{ user }}
-redirect_stderr=false
+autostart={{ autostart }}
+autorestart={{ autorestart }}
+startsecs={{ startsecs }}
+startretries={{ startretries }}
+exitcodes={{ exitcodes }}
+stopsignal={{ stopsignal }}
+stopwaitsecs={{ stopwaitsecs }}
+redirect_stderr={{ redirect_stderr }}
+numprocs={{ numprocs }}


### PR DESCRIPTION
### What

Made the options for configuring a Supervisor managed process configurable.
This makes configuring a Supervisor managed process very flexible :+1: 

### Why

I wanted to run a managed Laravel Artisan queue worker, but `php artisan queue:restart` will make the worker exit with code 0, which was by default configured as an 'expected' exit status, so Supervisor will not restart the process automatically.

Now I have the power to configure this behaviour so Supervisor will in fact restart the queue worker if killed intentionally (e.g. when updating).

I can also now spawn multiple workers with the added setting numprocs.

### Backwards compatibility

I kept all the default options exactly the same as before, so without configuring queue workers and simply updating this formula, nothing should change.

