### PR TITLE
The program name is now dynamically set if the number of processes ar…

### DIFF
--- a/supervisor/conf.sls
+++ b/supervisor/conf.sls
@@ -4,6 +4,12 @@
 {%- set processes = salt['pillar.get']('supervisor:processes', {}) %}
 {%- if processes %}
 {%- for id, process_data in processes.items() %}
+
+{% set process_name = "%(program_name)s" %}
+{% if process_data.numprocs is defined and process_data.numprocs > 1 %}
+{% set process_name = "%(program_name)s_%(process_num)02d" %}
+{% endif %}
+
 supervisor_job_{{ id }}:
   file.managed:
     - name: /etc/supervisor/conf.d/{{ id }}.conf
@@ -21,6 +27,7 @@ supervisor_job_{{ id }}:
         stopwaitsecs: 10
         redirect_stderr: "false"
         numprocs: 1
+        process_name: "{{ process_name }}"
     - watch_in:
       - service: supervisor
     - require:

--- a/supervisor/templates/process.conf.jinja
+++ b/supervisor/templates/process.conf.jinja
@@ -12,3 +12,4 @@ stopsignal={{ stopsignal }}
 stopwaitsecs={{ stopwaitsecs }}
 redirect_stderr={{ redirect_stderr }}
 numprocs={{ numprocs }}
+process_name={{ process_name }}


### PR DESCRIPTION
### What has been done
- Automatically set the program name based upon the process name + process id, if numprocs is set to more than 1.

### How to test
- Configure a Supervisor worker to have numprocs 3
- See the generated .conf that contains the right processname